### PR TITLE
Added a div with a message for when media fails to be fetched.

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -650,7 +650,7 @@ const replaceFailedMediaWithMessage = async (content, failedUrls) => {
   if (!content || !failedUrls || failedUrls.length === 0) return content;
 
   let result = content;
-  const fallbackDiv = `<span style="border: 3px solid #000; background-color: #e9b833; color: #000; padding: 0.75rem; margin: 0.75rem 0;">${escapeHtml(failedMediaFallbackMessage)}</span>`;
+  const fallbackDiv = `<div style="border: 3px solid #000; background-color: #e9b833; color: #000; padding: 0.75rem; margin: 0.75rem 0;">${escapeHtml(failedMediaFallbackMessage)}</div>`;
 
   for (const originalUrl of failedUrls) {
     const normalizedUrl = normalizeMediaUrl(originalUrl);


### PR DESCRIPTION
I have logic in the app that tries to fatch the linked media in GitHub Issues but can't right now because I need to build out some backend elements. So for now I just have a fallback message that informs the user that media was supposed to be present but couldn't be and that they should reach out to whomever sent them the files if they need the screenshots or videos for context.